### PR TITLE
Capitalize Menu Title

### DIFF
--- a/menus/browser-plus.cson
+++ b/menus/browser-plus.cson
@@ -2,7 +2,7 @@
 'context-menu':
   'atom-text-editor': [
     {
-      'label': 'Open browser-plus'
+      'label': 'Open Browser-Plus'
       'command': 'browser-plus:open'
     }
 


### PR DESCRIPTION
Fixed capitalization in the menu bar item to be consistent with all
other menu item titles in Atom.