### PR TITLE
Fixed favicon not updating between websites

### DIFF
--- a/lib/browser-plus-view.coffee
+++ b/lib/browser-plus-view.coffee
@@ -229,7 +229,7 @@ class BrowserPlusView extends View
 
       @htmlv[0]?.addEventListener "page-favicon-updated", (e)=>
         @model.browserPlus.favIcon[@model.uri] = icon = e.favicons[0]
-        @model.iconName = Math.floor(Math.random()*10000)
+        @model.iconName = Math.floor(Math.random()*10000).toString()
         @model.updateIcon()
         style = document.createElement('style')
         style.type = 'text/css'


### PR DESCRIPTION
When creating a new random name for a favicon, a random integer was generated:
`@model.iconName = Math.floor(Math.random()*10000)`
The `tabs` package, however expects a string. This caused the favicon to not only never update, but also a red error to show up from Atom, maybe the user experience terrible. The simple fix was to parse the `Int` to a `String`!