### PR TITLE
Implementation of Issue #133

### DIFF
--- a/lib/browser-plus-view.coffee
+++ b/lib/browser-plus-view.coffee
@@ -327,7 +327,7 @@ class BrowserPlusView extends View
             else
               localhostPattern = ///^
                                   (http://)?
-                                  localhost
+                                  ([a-zA-Z0-9]*)
                                   ///i
               if url.search(localhostPattern) < 0   and url.indexOf('.') < 0
                 url = "http://www.google.com/search?as_q=#{url}"
@@ -337,8 +337,8 @@ class BrowserPlusView extends View
                     url = url.replace(/\\/g,"/")
                   else
                     url = URL.format(urls)
-                else if url.indexOf('localhost') isnt  -1
-                  url = url.replace(localhostPattern,'http://127.0.0.1')
+                #else if url.indexOf('localhost') isnt  -1
+                #  url = url.replace(localhostPattern,'http://127.0.0.1')
                 else
                   urls.protocol = 'http'
                   url = URL.format(urls)

--- a/lib/browser-plus.coffee
+++ b/lib/browser-plus.coffee
@@ -48,7 +48,7 @@ module.exports = BrowserPlus =
           url.indexOf('browser-plus~') is 0 )
          localhostPattern = ///^
                               (http://)?
-                              localhost
+                              ([a-zA-Z0-9]*)
                               ///i
          return false unless BrowserPlusModel.checkUrl(url)
          #  check if it need to be open in same window
@@ -61,7 +61,7 @@ module.exports = BrowserPlus =
              pane.activateItem(editor)
              return editor
 
-         url = url.replace(localhostPattern,'http://127.0.0.1')
+         #url = url.replace(localhostPattern,'http://127.0.0.1')
          new BrowserPlusModel {browserPlus:@,url:url,opt:opt}
 
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable


### PR DESCRIPTION
Implementation of issue #133 
Although now any URL that matches *http://([a-zA-Z0-9]\*)/* is now treated as *localhost*, you can still configure *hosts* file to point any name with sub-domains to *127.0.0.1* but they will not be recognized as *localhost* and they will result in a google search.

This could be fixed by assuming that if the URL ends with */*, it's a localhost, or by actually checking that the URL translates to *127.0.0.1*